### PR TITLE
docs: warn about pip 25 and demucs

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,6 +67,19 @@ make
 pip install git+https://github.com/CPJKU/madmom  # install the latest madmom directly from GitHub
 pip install allin1  # install this package
 ```
+If you are using `pip>=25`, the build process of the `demucs` dependency might fail.
+As a temporary workaround, either downgrade pip and setuptools:
+
+```shell
+pip install "pip<25" "setuptools<69"
+pip install allin1
+```
+
+or set the environment variable before installation:
+
+```shell
+SETUPTOOLS_USE_DISTUTILS=stdlib pip install allin1
+```
 
 ### 4. (Optional) Install FFmpeg for MP3 support
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ dependencies = [
   "numpy",
   "librosa",
   "natten; platform_system == 'Darwin'",
-  "demucs",
+  "demucs==4.0.1",
   "hydra-core",
   "omegaconf",
   "huggingface_hub",


### PR DESCRIPTION
## Summary
- warn in README that demucs build may fail with `pip>=25`
- suggest workarounds via downgrading pip/setuptools or using `SETUPTOOLS_USE_DISTUTILS`
- pin demucs version to `4.0.1`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_684bfeac74088324abf303fa986d7f32