### PR TITLE
Update README with NATTEN install details

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,12 @@ sudo apt install python3.10 python3.10-distutils python3.10-dev build-essential
 Visit [PyTorch](https://pytorch.org/) and install the appropriate version for your system.
 
 ### 2. Install NATTEN (Required for Linux and Windows; macOS will auto-install)
-* **Linux**: Download from [NATTEN website](https://www.shi-labs.com/natten/)
+* **Linux**: Download from [NATTEN website](https://www.shi-labs.com/natten/). Убедитесь, что версия CUDA и Python в названии файла соответствует вашей установленной версии PyTorch (например, `natten-<ver>+torch<...>cu<...>-cp<py>-...whl`). Пример для CUDA 12.6, PyTorch 2.7 и Python 3.10:
+```bash
+wget https://github.com/SHI-Labs/NATTEN/releases/download/v0.20.0/natten-0.20.0+torch270cu126-cp310-cp310-linux_x86_64.whl
+pip install natten-0.20.0+torch270cu126-cp310-cp310-linux_x86_64.whl
+```
+Для других версий возьмите аналогичный файл.
 * **macOS**: Auto-installs with `allin1`.
 * **Windows**: Build from source:
 ```shell


### PR DESCRIPTION
## Summary
- expand the "Install NATTEN" section in `README.md` with instructions to check CUDA and Python versions
- show an example command for Linux and note that other versions should use the matching wheel

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'allin1')*

------
https://chatgpt.com/codex/tasks/task_e_684c095ed0cc832489cc069377565a3d